### PR TITLE
fix: empty apiKey should passed auth.guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run -d \
   -e POSTGRES_PASSWORD=your_password \
   -e POSTGRES_DB=your_database \
   -p 5432:5432 \
-  pgvector/pgvector
+  pgvector/pgvector:pg17
 ```
 
 #### Manual Installation

--- a/src/modules/auth/services/auth.guard.ts
+++ b/src/modules/auth/services/auth.guard.ts
@@ -17,7 +17,8 @@ export class AuthGuard implements CanActivate {
   ): boolean | Promise<boolean> | Observable<boolean> {
     const apiKey = ConnectorHiveConfiguration.API_KEY();
 
-    if (apiKey == null) {
+    // check null, undefined, empty string
+    if (!apiKey) {
       // API Key is not set, so we should allow all requests
       return true;
     }


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and improvements to the `AuthGuard` class in the `auth.guard.ts` file. The most important changes are:

Documentation update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R24): Updated the Docker command to specify the `pg17` tag for the `pgvector/pgvector` image.

Code improvement:
* [`src/modules/auth/services/auth.guard.ts`](diffhunk://#diff-8f920ebb2f0aef530b5911f48c1c4e31d04eb0535fd3e0e2c7b2cfe74ae2fb31L20-R21): Enhanced the null check for the API key by using a more comprehensive condition that checks for null, undefined, and empty string values.