### PR TITLE
fix: use transaction with serializable

### DIFF
--- a/src/modules/connector/services/application.version.service.ts
+++ b/src/modules/connector/services/application.version.service.ts
@@ -1,7 +1,6 @@
 import {
   ConflictException,
   Injectable,
-  InternalServerErrorException,
   NotFoundException,
 } from "@nestjs/common";
 import { Prisma } from "@prisma/client";

--- a/src/modules/connector/services/application.version.service.ts
+++ b/src/modules/connector/services/application.version.service.ts
@@ -221,19 +221,19 @@ export class ApplicationVersionService {
         return this.db.$transaction(
           async (db) => {
             const created = await db.$queryRaw`
-            INSERT INTO "public"."ApplicationVersion" (
-              "applicationId",
-              "version"
-            ) VALUES (
-              ${applicationId},
-              (
-                SELECT COALESCE(MAX("version"), 0) + 1
-                FROM "public"."ApplicationVersion"
-                WHERE "applicationId" = ${applicationId}
+              INSERT INTO "public"."ApplicationVersion" (
+                "applicationId",
+                "version"
+              ) VALUES (
+                ${applicationId},
+                (
+                  SELECT COALESCE(MAX("version"), 0) + 1
+                  FROM "public"."ApplicationVersion"
+                  WHERE "applicationId" = ${applicationId}
+                )
               )
-            )
-            RETURNING "id", "version", "createdAt"
-          `;
+              RETURNING "id", "version", "createdAt"
+            `;
 
             interface IRawApplicationVersion {
               id: string & typia.tags.Format<"uuid">;

--- a/src/modules/connector/services/application.version.service.ts
+++ b/src/modules/connector/services/application.version.service.ts
@@ -219,18 +219,20 @@ export class ApplicationVersionService {
     for (let attempt = 0; attempt < 10; ++attempt) {
       const created = await this.db.$queryRaw`
         INSERT INTO "public"."ApplicationVersion" (
+          "id",
           "applicationId",
           "version"
         ) VALUES (
-          ${applicationId},
+          gen_random_uuid(),
+          ${applicationId}::uuid,
           (
             SELECT COALESCE(MAX("version"), 0) + 1
             FROM "public"."ApplicationVersion"
-            WHERE "applicationId" = ${applicationId}
+            WHERE "applicationId" = ${applicationId}::uuid
           )
         )
-        RETURNING "id", "version", "createdAt"
         ON CONFLICT DO NOTHING
+        RETURNING "id", "version", "createdAt"
       `;
 
       interface IRawApplicationVersion {


### PR DESCRIPTION
This PR resolves the problem that the server returns 500 internal server error when the client creates massive amount of application creation requests in parallel.

It adds `ON CONFLICT DO NOTHING` clause, and introduces retry attempts with random delay.
